### PR TITLE
Handle loading state errors

### DIFF
--- a/src/AppState.cs
+++ b/src/AppState.cs
@@ -48,8 +48,16 @@ namespace CommandLauncher
         {
             if (File.Exists(AppStateFilePath))
             {
-                var json = File.ReadAllText(AppStateFilePath);
-                _state = JsonSerializer.Deserialize<State>(json) ?? new State();
+                try
+                {
+                    var json = File.ReadAllText(AppStateFilePath);
+                    _state = JsonSerializer.Deserialize<State>(json) ?? new State();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError("读取应用状态失败", ex);
+                    // 保持 _state 为默认值
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- log errors when loading app state fails

## Testing
- `dotnet build windows-global-launcher.csproj` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844232d4f248322ae36205808e1fa86