### PR TITLE
Add xUnit tests for fuzzy matching

### DIFF
--- a/tests/CommandLauncher.Tests/CommandLauncher.Tests.csproj
+++ b/tests/CommandLauncher.Tests/CommandLauncher.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\windows-global-launcher.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/CommandLauncher.Tests/FuzzyMatcherTests.cs
+++ b/tests/CommandLauncher.Tests/FuzzyMatcherTests.cs
@@ -1,0 +1,39 @@
+using CommandLauncher;
+using Xunit;
+
+namespace CommandLauncher.Tests
+{
+    public class FuzzyMatcherTests
+    {
+        [Theory]
+        [InlineData("abc", "abc", 1.0)]
+        [InlineData("ab", "abc", 0.6666666666666667)]
+        [InlineData("ABC", "abc", 1.0)]
+        public void GetMatchScore_ReturnsExpectedScore(string query, string target, double expected)
+        {
+            var score = FuzzyMatcher.GetMatchScore(query, target);
+            Assert.Equal(expected, score, 5);
+        }
+
+        [Fact]
+        public void GetCommandMatchScore_ReturnsHighestFieldScore()
+        {
+            var command = new Command
+            {
+                Name = "foo",
+                Description = "bar",
+                Shell = "baz"
+            };
+
+            var scoreDesc = FuzzyMatcher.GetCommandMatchScore("bar", command);
+            Assert.Equal(1.0, scoreDesc, 5);
+
+            var expectedPartial = FuzzyMatcher.GetMatchScore("fo", command.Name);
+            var scorePartial = FuzzyMatcher.GetCommandMatchScore("fo", command);
+            Assert.Equal(expectedPartial, scorePartial, 5);
+
+            var scoreCase = FuzzyMatcher.GetCommandMatchScore("FOO", command);
+            Assert.Equal(1.0, scoreCase, 5);
+        }
+    }
+}

--- a/windows-global-laucher.sln
+++ b/windows-global-laucher.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "windows-global-launcher", "windows-global-launcher.csproj", "{95DF2733-F0B6-9CD1-610D-F9377B8696A5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandLauncher.Tests", "tests/CommandLauncher.Tests/CommandLauncher.Tests.csproj", "{27254BD0-C125-4CC0-B637-FBB66BFF264B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,8 +15,12 @@ Global
 		{95DF2733-F0B6-9CD1-610D-F9377B8696A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{95DF2733-F0B6-9CD1-610D-F9377B8696A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{95DF2733-F0B6-9CD1-610D-F9377B8696A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{95DF2733-F0B6-9CD1-610D-F9377B8696A5}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {95DF2733-F0B6-9CD1-610D-F9377B8696A5}.Release|Any CPU.Build.0 = Release|Any CPU
+                {27254BD0-C125-4CC0-B637-FBB66BFF264B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {27254BD0-C125-4CC0-B637-FBB66BFF264B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {27254BD0-C125-4CC0-B637-FBB66BFF264B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {27254BD0-C125-4CC0-B637-FBB66BFF264B}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add new xUnit test project
- cover fuzzy match scoring logic

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844232f678483228706cc6dc43bf9b3