### PR TITLE
Add basic xUnit tests

### DIFF
--- a/WindowsGlobalLauncher.sln
+++ b/WindowsGlobalLauncher.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsGlobalLauncher", "src/WindowsGlobalLauncher/WindowsGlobalLauncher.csproj", "{95DF2733-F0B6-9CD1-610D-F9377B8696A5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsGlobalLauncher.Tests", "tests/WindowsGlobalLauncher.Tests/WindowsGlobalLauncher.Tests.csproj", "{52A1B87E-6D1E-452B-908B-F92178857591}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,7 +16,11 @@ Global
 		{95DF2733-F0B6-9CD1-610D-F9377B8696A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{95DF2733-F0B6-9CD1-610D-F9377B8696A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95DF2733-F0B6-9CD1-610D-F9377B8696A5}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+		{52A1B87E-6D1E-452B-908B-F92178857591}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52A1B87E-6D1E-452B-908B-F92178857591}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52A1B87E-6D1E-452B-908B-F92178857591}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52A1B87E-6D1E-452B-908B-F92178857591}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/tests/WindowsGlobalLauncher.Tests/FuzzyMatcherTests.cs
+++ b/tests/WindowsGlobalLauncher.Tests/FuzzyMatcherTests.cs
@@ -1,0 +1,32 @@
+using CommandLauncher;
+using Xunit;
+
+namespace WindowsGlobalLauncher.Tests;
+
+public class FuzzyMatcherTests
+{
+    [Theory]
+    [InlineData("abc", "abc", 1.0)]
+    [InlineData("abc", "abcde", 0.6)]
+    [InlineData("ace", "abcde", 0.48)]
+    [InlineData("xyz", "abcde", 0)]
+    public void GetMatchScore_WorksAsExpected(string query, string target, double expected)
+    {
+        double score = FuzzyMatcher.GetMatchScore(query, target);
+        Assert.Equal(expected, score, 3);
+    }
+
+    [Fact]
+    public void GetCommandMatchScore_ReturnsMaxOfProperties()
+    {
+        var cmd = new Command
+        {
+            Name = "list",
+            Description = "list files",
+            Shell = "ls"
+        };
+
+        double score = FuzzyMatcher.GetCommandMatchScore("ls", cmd);
+        Assert.Equal(1.0, score, 3);
+    }
+}

--- a/tests/WindowsGlobalLauncher.Tests/WindowsGlobalLauncher.Tests.csproj
+++ b/tests/WindowsGlobalLauncher.Tests/WindowsGlobalLauncher.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/WindowsGlobalLauncher/WindowsGlobalLauncher.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add new xUnit test project
- cover `FuzzyMatcher` score calculations with tests
- include test project in solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684431480b388322b1c2db4d514eddfb