### PR TITLE
Fix command list scroll position

### DIFF
--- a/src/WindowsGlobalLauncher/MainWindow.cs
+++ b/src/WindowsGlobalLauncher/MainWindow.cs
@@ -439,7 +439,7 @@ namespace CommandLauncher
             _placeholder.Visibility = string.IsNullOrEmpty(_searchBox.Text) ? Visibility.Visible : Visibility.Hidden;
 
             RefreshCommandList();
-            SelectLastExecutedCommand();
+            ScrollCommandListToTop();
         }
 
         private void CenterWindowOnCurrentScreen()
@@ -553,6 +553,16 @@ namespace CommandLauncher
                 var lastExecuted = _filteredCommands.OrderByDescending(c => c.LastExecuted).First();
                 _selectedIndex = _filteredCommands.IndexOf(lastExecuted);
                 _commandList.SelectedIndex = _selectedIndex;
+            }
+        }
+
+        private void ScrollCommandListToTop()
+        {
+            if (_commandList.Items.Count > 0)
+            {
+                _selectedIndex = 0;
+                _commandList.SelectedIndex = _selectedIndex;
+                _commandList.ScrollIntoView(_commandList.Items[0]);
             }
         }
 


### PR DESCRIPTION
## Summary
- keep command list at top when opening main window

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450c55e38883229d9f3a653bd07bb2