### PR TITLE
Implement persistent search text

### DIFF
--- a/src/WindowsGlobalLauncher/MainWindow.cs
+++ b/src/WindowsGlobalLauncher/MainWindow.cs
@@ -103,6 +103,9 @@ namespace CommandLauncher
         private readonly TextBlock _placeholder = CreatePlaceholder();
         private readonly ListBox _commandList = CreateCommandList();
 
+        // When true, HideWindow will keep the search text instead of clearing it
+        private bool _preserveSearchText = false;
+
         public MainWindow()
         {
             // 支持命令行指定配置文件路径
@@ -721,6 +724,7 @@ namespace CommandLauncher
         {
             try
             {
+                _preserveSearchText = !string.IsNullOrEmpty(_searchBox.Text);
                 ExecuteCommandImpl(selectedCommand);
                 AppState.Instance.SetCommandLastExecutedTime(selectedCommand.Name, DateTime.Now);
                 HideWindow();
@@ -798,7 +802,11 @@ namespace CommandLauncher
         private void HideWindow()
         {
             Hide();
-            _searchBox.Clear();
+            if (!_preserveSearchText)
+            {
+                _searchBox.Clear();
+            }
+            _preserveSearchText = false;
         }
 
         private void ExitApplication()


### PR DESCRIPTION
## Summary
- keep search text when hiding the window after executing a command

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684513b40390832291a45f13a958fa30